### PR TITLE
Ability to detect more than 1 phenomena

### DIFF
--- a/src/ChunkDecoder/CloudChunkDecoder.php
+++ b/src/ChunkDecoder/CloudChunkDecoder.php
@@ -49,6 +49,7 @@ class CloudChunkDecoder extends TafChunkDecoder implements TafChunkDecoderInterf
                     } else {
                         $layer_height_ft = null;
                     }
+                    $layer->setChunk(trim($found[$i]));
                     $layer->setAmount($found[$i+1])
                         ->setBaseHeight(Value::newValue($layer_height_ft, Value::FEET))
                         ->setType($found[$i+3]);

--- a/src/ChunkDecoder/EvolutionChunkDecoder.php
+++ b/src/ChunkDecoder/EvolutionChunkDecoder.php
@@ -211,8 +211,10 @@ class EvolutionChunkDecoder extends TafChunkDecoder implements TafChunkDecoderIn
             $periodArr = explode('/', $period);
             $embeddedEvolution->setFromDay(intval(mb_substr($periodArr[0], 0, 2)));
             $embeddedEvolution->setFromTime(mb_substr($periodArr[0], 2, 2) . ':00 UTC');
-            $embeddedEvolution->setToDay(intval(mb_substr($periodArr[1], 0, 2)));
-            $embeddedEvolution->setToTime(mb_substr($periodArr[1], 2, 2) . ':00 UTC');
+            if(isset($periodArr[1])){
+                $embeddedEvolution->setToDay(intval(mb_substr($periodArr[1], 0, 2)));
+                $embeddedEvolution->setToTime(mb_substr($periodArr[1], 2, 2) . ':00 UTC');
+            }
 
             $evolution->addEvolution($embeddedEvolution);
             // recurse on the remaining chunk to extract the weather elements it contains

--- a/src/ChunkDecoder/SurfaceWindChunkDecoder.php
+++ b/src/ChunkDecoder/SurfaceWindChunkDecoder.php
@@ -61,6 +61,8 @@ class SurfaceWindChunkDecoder extends TafChunkDecoder implements TafChunkDecoder
         // retrieve and validate found params
         $surface_wind = new SurfaceWind();
 
+        $surface_wind->setChunk(trim($found[0]));
+
         // mean speed
         $surface_wind->setMeanSpeed(Value::newIntValue($found[2], $speed_unit));
 

--- a/src/ChunkDecoder/VisibilityChunkDecoder.php
+++ b/src/ChunkDecoder/VisibilityChunkDecoder.php
@@ -45,6 +45,7 @@ class VisibilityChunkDecoder extends TafChunkDecoder implements TafChunkDecoderI
             $cavok = false;
             $visibility = new Visibility();
             if (trim($found[2]) != null) { // icao visibility
+                $visibility->setChunk(trim($found[1]));
                 $visibility->setVisibility(Value::newIntValue($found[2], Value::METER));
             } else { // us visibility
                 $main = intval($found[4]);
@@ -56,6 +57,7 @@ class VisibilityChunkDecoder extends TafChunkDecoder implements TafChunkDecoderI
                 } else {
                     $vis_value = $main;
                 }
+                $visibility->setChunk(trim($found[1]));
                 $visibility->setVisibility(Value::newValue($vis_value, Value::STATUTE_MILE));
                 $visibility->setGreater($is_greater);
             }

--- a/src/ChunkDecoder/WeatherChunkDecoder.php
+++ b/src/ChunkDecoder/WeatherChunkDecoder.php
@@ -26,9 +26,9 @@ class WeatherChunkDecoder extends TafChunkDecoder implements TafChunkDecoderInte
     {
         $desc_regexp = implode(self::$desc_dic, '|');
         $phenom_regexp = implode(self::$phenom_dic, '|');
-        $pw_regexp = "([-+]|VC)?($desc_regexp)?($phenom_regexp)?($desc_regexp)?($phenom_regexp)?";
+        $pw_regexp = "([-+]|VC)?($desc_regexp)?($phenom_regexp)?($phenom_regexp)?($phenom_regexp)?";
 
-        return "#^($pw_regexp )?()?#";
+        return "#^($pw_regexp )?($pw_regexp )?($pw_regexp )?()?#";
     }
 
     public function parse($remaining_taf, $cavok = false)
@@ -37,19 +37,24 @@ class WeatherChunkDecoder extends TafChunkDecoder implements TafChunkDecoderInte
         $found = $result['found'];
         $new_remaining_taf = $result['remaining'];
 
-        $weatherPhenom = null;
-        if (trim($found[1]) != null && $found[4] != '//') {
-            $weatherPhenom = new WeatherPhenomenon();
-            $weatherPhenom->setIntensityProximity($found[2]);
-            $weatherPhenom->setDescriptor($found[3]);
-            for ($k = 3; $k <= 5; $k++) {
-                if ($found[1+$k] != null) {
-                    $weatherPhenom->addPhenomenon($found[1+$k]);
+        $phenomenons = null;
+
+        for ($i = 1; $i <= 13; $i += 6) {
+            if ($found[$i] != null && $found[$i + 3] != '//') {
+                $weatherPhenom = new WeatherPhenomenon();
+                $weatherPhenom->setIntensityProximity($found[$i + 1]);
+                $weatherPhenom->setDescriptor($found[$i + 2]);
+                for ($k = 3; $k <= 5; ++$k) {
+                    if ($found[$i + $k] != null) {
+                        $weatherPhenom->addPhenomenon($found[$i + $k]);
+                    }
                 }
+                $phenomenons[] = $weatherPhenom;
             }
         }
+
         $result = array(
-            'weatherPhenomenon' => $weatherPhenom,
+            'weatherPhenomenon' => $phenomenons,
         );
 
         // return result + remaining taf

--- a/src/ChunkDecoder/WeatherChunkDecoder.php
+++ b/src/ChunkDecoder/WeatherChunkDecoder.php
@@ -19,15 +19,15 @@ class WeatherChunkDecoder extends TafChunkDecoder implements TafChunkDecoderInte
         'SA', 'DU', 'HZ', 'FU',
         'VA', 'PY', 'DU', 'PO',
         'SQ', 'FC', 'DS', 'SS',
-        '//',
+        '//', "NSW"
     );
 
     public function getRegexp()
     {
         $desc_regexp = implode(self::$desc_dic, '|');
         $phenom_regexp = implode(self::$phenom_dic, '|');
-        $pw_regexp = "([-+]|VC)?($desc_regexp)?($phenom_regexp)?($desc_regexp)?($phenom_regexp)?";
-
+        $pw_regexp = "([-+]|VC)?($desc_regexp)?($phenom_regexp)?(?:\s)?($desc_regexp)?($phenom_regexp)?";
+        
         return "#^($pw_regexp )?()?#";
     }
 

--- a/src/ChunkDecoder/WeatherChunkDecoder.php
+++ b/src/ChunkDecoder/WeatherChunkDecoder.php
@@ -40,6 +40,7 @@ class WeatherChunkDecoder extends TafChunkDecoder implements TafChunkDecoderInte
         $weatherPhenom = null;
         if (trim($found[1]) != null && $found[4] != '//') {
             $weatherPhenom = new WeatherPhenomenon();
+            $weatherPhenom->setChunk(trim($found[1]));
             $weatherPhenom->setIntensityProximity($found[2]);
             $weatherPhenom->setDescriptor($found[3]);
             for ($k = 3; $k <= 5; $k++) {

--- a/src/Entity/CloudLayer.php
+++ b/src/Entity/CloudLayer.php
@@ -2,7 +2,7 @@
 
 namespace TafDecoder\Entity;
 
-class CloudLayer
+class CloudLayer extends InformationBase
 {
     // annotation corresponding to amount of clouds (FEW/SCT/BKN/OVC)
     private $amount;

--- a/src/Entity/InformationBase.php
+++ b/src/Entity/InformationBase.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace TafDecoder\Entity;
+
+
+class InformationBase
+{
+    // chunk detected for decoding
+    private $chunk;
+
+    public function getChunk()
+    {
+        return $this->chunk;
+    }
+
+    public function setChunk($chunk)
+    {
+        $this->chunk = $chunk;
+    }
+}

--- a/src/Entity/SurfaceWind.php
+++ b/src/Entity/SurfaceWind.php
@@ -2,7 +2,7 @@
 
 namespace TafDecoder\Entity;
 
-class SurfaceWind
+class SurfaceWind extends InformationBase
 {
     // wind direction
     private $mean_direction;

--- a/src/Entity/Visibility.php
+++ b/src/Entity/Visibility.php
@@ -2,7 +2,7 @@
 
 namespace TafDecoder\Entity;
 
-class Visibility
+class Visibility extends InformationBase
 {
     // prevailing visibility
     private $visibility;

--- a/src/Entity/WeatherPhenomenon.php
+++ b/src/Entity/WeatherPhenomenon.php
@@ -2,7 +2,7 @@
 
 namespace TafDecoder\Entity;
 
-class WeatherPhenomenon
+class WeatherPhenomenon extends InformationBase
 {
     // intensity/proximity of the phenomenon + / - / VC (heavy, light, vicinity)
     private $intensity_proximity;

--- a/tests/ChunkDecoder/WeatherChunkDecoderTest.php
+++ b/tests/ChunkDecoder/WeatherChunkDecoderTest.php
@@ -65,6 +65,34 @@ class WeatherChunkDecoderTest extends \PHPUnit_Framework_TestCase
                 "weather_phenom"    => array("RA","BR"),
                 "remaining"         => "DDD",
             ),
+            array(
+                "chunk"             => "-SN BR DDD",
+                "weather_inten"     => "-",
+                "weather_desc"      => "",
+                "weather_phenom"    => array("SN","BR"),
+                "remaining"         => "DDD",
+            ),
+            array(
+                "chunk"             => "-RA BR DDD",
+                "weather_inten"     => "-",
+                "weather_desc"      => "",
+                "weather_phenom"    => array("RA","BR"),
+                "remaining"         => "DDD",
+            ),
+            array(
+                "chunk"             => "NSW DDD",
+                "weather_inten"     => "",
+                "weather_desc"      => "",
+                "weather_phenom"    => array("NSW"),
+                "remaining"         => "DDD",
+            ),
+            array(
+                "chunk"             => "-DZ FG DDD",
+                "weather_inten"     => "-",
+                "weather_desc"      => "",
+                "weather_phenom"    => array("DZ", "FG"),
+                "remaining"         => "DDD",
+            ),
         );
     }
 }

--- a/tests/ChunkDecoder/WeatherChunkDecoderTest.php
+++ b/tests/ChunkDecoder/WeatherChunkDecoderTest.php
@@ -17,20 +17,22 @@ class WeatherChunkDecoderTest extends \PHPUnit_Framework_TestCase
     /**
      * Test parsing of valid weather chunks
      * @param $chunk
-     * @param $weather_intens
-     * @param $weather_desc
-     * @param $weather_phenom
+     * @param $test_weather_phenoms
      * @param $remaining
      * @dataProvider getChunk
      */
-    public function testParse($chunk, $weather_intens, $weather_desc, $weather_phenom, $remaining)
+    public function testParse($chunk, $test_weather_phenoms, $remaining)
     {
+        $i = 0;
         $decoded = $this->decoder->parse($chunk);
         /** @var WeatherPhenomenon $weather */
-        $weather = $decoded['result']['weatherPhenomenon'];
-        $this->assertEquals($weather_intens, $weather->getIntensityProximity());
-        $this->assertEquals($weather_desc, $weather->getDescriptor());
-        $this->assertEquals($weather_phenom, $weather->getPhenomena());
+        $weatherArray = $decoded['result']['weatherPhenomenon'];
+        foreach ($weatherArray as $weather) {
+            $this->assertEquals($test_weather_phenoms[$i]['weather_intens'], $weather->getIntensityProximity());
+            $this->assertEquals($test_weather_phenoms[$i]['weather_desc'], $weather->getDescriptor());
+            $this->assertEquals($test_weather_phenoms[$i]['weather_phenom'], $weather->getPhenomena());
+            $i++;
+        }
         $this->assertEquals($remaining, $decoded['remaining_taf']);
     }
 
@@ -38,32 +40,64 @@ class WeatherChunkDecoderTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(
-                "chunk"             => "VCBLSN AAA",
-                "weather_intens"    => "VC",
-                "weather_desc"      => "BL",
-                "weather_phenom"    => array("SN"),
-                "remaining"         => "AAA",
+                "chunk" => "VCBLSN AAA",
+                array(
+                    array(
+                        "weather_intens" => "VC",
+                        "weather_desc" => "BL",
+                        "weather_phenom" => array("SN")
+                    )
+                ),
+                "remaining" => "AAA",
             ),
             array(
-                "chunk"             => "-PL BBB",
-                "weather_intens"    => "-",
-                "weather_desc"      => "",
-                "weather_phenom"    => array("PL"),
-                "remaining"         => "BBB",
+                "chunk" => "-PL BBB",
+                array(
+                    array(
+                        "weather_intens" => "-",
+                        "weather_desc" => "",
+                        "weather_phenom" => array("PL")
+                    )
+                ),
+                "remaining" => "BBB",
             ),
             array(
-                "chunk"             => "+TSRA CCC",
-                "weather_intens"    => "+",
-                "weather_desc"      => "TS",
-                "weather_phenom"    => array("RA"),
-                "remaining"         => "CCC",
+                "chunk" => "+TSRA CCC",
+                array(
+                    array(
+                        "weather_intens" => "+",
+                        "weather_desc" => "TS",
+                        "weather_phenom" => array("RA")
+                    )
+                ),
+                "remaining" => "CCC",
             ),
             array(
-                "chunk"             => "TSRABR DDD",
-                "weather_inten"     => "",
-                "weather_desc"      => "TS",
-                "weather_phenom"    => array("RA","BR"),
-                "remaining"         => "DDD",
+                "chunk" => "TSRABR DDD",
+                array(
+                    array(
+                        "weather_intens" => "",
+                        "weather_desc" => "TS",
+                        "weather_phenom" => array("RA", "BR")
+                    )
+                ),
+                "remaining" => "DDD",
+            ),
+            array(
+                "chunk" => "-DZ FG DDD",
+                array(
+                    array(
+                        "weather_intens" => "-",
+                        "weather_desc" => "",
+                        "weather_phenom" => array("DZ")
+                    ),
+                    array(
+                        "weather_intens" => "",
+                        "weather_desc" => "",
+                        "weather_phenom" => array("FG")
+                    )
+                ),
+                "remaining" => "DDD",
             ),
         );
     }

--- a/tests/TafDecoderTest.php
+++ b/tests/TafDecoderTest.php
@@ -61,11 +61,70 @@ class TafDecoderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($v->getGreater());
         /** @var WeatherPhenomenon $wp */
         $wp = $d->getWeatherPhenomenon();
-        $this->assertEquals('-', $wp->getIntensityProximity());
-        $this->assertEquals('SH', $wp->getDescriptor());
-        $phenomena = $wp->getPhenomena();
+        $this->assertEquals('-', $wp[0]->getIntensityProximity());
+        $this->assertEquals('SH', $wp[0]->getDescriptor());
+        $phenomena = $wp[0]->getPhenomena();
         $this->assertEquals('DZ', $phenomena[0]);
         $this->assertEquals('RA', $phenomena[1]);
+        $cls = $d->getClouds();
+        /** @var CloudLayer $cl */
+        $cl = $cls[0];
+        $this->assertEquals('BKN', $cl->getAmount());
+        $this->assertEquals(2000, $cl->getBaseHeight()->getValue());
+        $this->assertEquals('ft', $cl->getBaseHeight()->getUnit());
+        $this->assertEquals('CB', $cl->getType());
+        /** @var Temperature $mint */
+        $mint = $d->getMinTemperature();
+        $this->assertEquals(-3, $mint->getTemperature()->getValue());
+        $this->assertEquals('deg C', $mint->getTemperature()->getUnit());
+        $this->assertEquals(4, $mint->getDay());
+        $this->assertEquals(5, $mint->getHour());
+        /** @var Temperature $maxt */
+        $maxt = $d->getMaxTemperature();
+        $this->assertEquals(5, $maxt->getTemperature()->getValue());
+        $this->assertEquals('deg C', $maxt->getTemperature()->getUnit());
+        $this->assertEquals(3, $maxt->getDay());
+        $this->assertEquals(18, $maxt->getHour());
+
+    }
+
+    /**
+     * Test parsing of a valid TAF
+     */
+    public function testParseSecond()
+    {
+        $raw_taf = "TAF TAF LIRU 032244Z 0318/0406 23010KT P6SM BKN020CB TX05/0318Z TNM03/0405Z";
+        $d       = $this->decoder->parseStrict($raw_taf);
+
+        $this->assertTrue($d->isValid());
+        $this->assertEquals("TAF TAF LIRU 032244Z 0318/0406 23010KT P6SM BKN020CB TX05/0318Z TNM03/0405Z", $d->getRawTaf());
+        $this->assertEquals('TAF', $d->getType());
+        $this->assertEquals('LIRU', $d->getIcao());
+        $this->assertEquals(3, $d->getDay());
+        $this->assertEquals('22:44 UTC', $d->getTime());
+        /** @var ForecastPeriod $fp */
+        $fp = $d->getForecastPeriod();
+        $this->assertEquals(3, $fp->getFromDay());
+        $this->assertEquals(18, $fp->getFromHour());
+        $this->assertEquals(4, $fp->getToDay());
+        $this->assertEquals(6, $fp->getToHour());
+        /** @var SurfaceWind $sw */
+        $sw = $d->getSurfaceWind();
+        $this->assertFalse($sw->withVariableDirection());
+        $this->assertEquals(230, $sw->getMeanDirection()->getValue());
+        $this->assertEquals('deg', $sw->getMeanDirection()->getUnit());
+        $this->assertNull($sw->getDirectionVariations());
+        $this->assertEquals(10, $sw->getMeanSpeed()->getValue());
+        $this->assertEquals('kt', $sw->getMeanSpeed()->getUnit());
+        $this->assertNull($sw->getSpeedVariations());
+        /** @var Visibility $v */
+        $v = $d->getVisibility();
+        $this->assertEquals(6, $v->getVisibility()->getValue());
+        $this->assertEquals('SM', $v->getVisibility()->getUnit());
+        $this->assertTrue($v->getGreater());
+        /** @var WeatherPhenomenon $wp */
+        $wp = $d->getWeatherPhenomenon();
+        $this->assertEquals(null, $wp);
         $cls = $d->getClouds();
         /** @var CloudLayer $cl */
         $cl = $cls[0];


### PR DESCRIPTION
Hi @inouire, @jpjoux 

Not sure what is the reason for taf-decoder no to have same phenomenon processing as metar-decoder?

This PR proposes same implementation as metar-decoder. 
WeatherChunkDecoder and tests.

Kind regards,
Deniss

P.S. I do apologize for changing array formatting in tests (tabs after =>) - if you consider this a requirements - I will change formatting to original one. 