### PR TITLE
Fixed a validation test in ForecastPeriod.php

### DIFF
--- a/src/Entity/ForecastPeriod.php
+++ b/src/Entity/ForecastPeriod.php
@@ -24,8 +24,8 @@ class ForecastPeriod
     {
         // check that attribute aren't null
         if (
-            $this->getFromDay() == null || $this->getFromHour() == null ||
-            $this->getToDay() == null || $this->getToHour() == null
+            $this->getFromDay() == null || $this->getFromHour() === null ||
+            $this->getToDay() == null || $this->getToHour() === null
         ) {
             return false;
         }


### PR DESCRIPTION
The tests `$this->getFromHour() == null` and `$this->getToHour() == null` failed when the hour was 0. They shouldn't have, as 0 is a valid hour (unlike null).